### PR TITLE
Satosa in userspace without CHMOD

### DIFF
--- a/Docker-compose/docker-compose.yml
+++ b/Docker-compose/docker-compose.yml
@@ -62,12 +62,9 @@ services:
 
   satosa-saml2spid:
     image: ghcr.io/italia/satosa-saml2spid:latest
-    #image: satosa-saml2spid:latest
-    #build: 
-    #    context: ../      
-    #    args: 
-    #        - NODE_ENV=local        
-    #    dockerfile: Dockerfile
+    build: 
+      context: ../      
+      dockerfile: Dockerfile
     container_name: satosa-saml2spid
     # depends_on:
     #  - satosa-mongo

--- a/example/proxy_conf.yaml
+++ b/example/proxy_conf.yaml
@@ -50,39 +50,39 @@ LOGGING:
     syslog:
       format: "[SATOSA] [%(name)s] [%(levelname)s]: %(message)s"
   handlers:
-    spid_daily:
-      class: logging.handlers.TimedRotatingFileHandler
-      level: INFO
-      formatter: simple
-      filename: logs/spid.log
-      when: D
-      interval: 1
-      backupCount: 860
-    syslog:
-      class: logging.handlers.SysLogHandler
-      level: INFO
-      formatter: syslog
     console:
       class: logging.StreamHandler
       level: DEBUG
       formatter: simple
       stream: ext://sys.stdout
-    saml2_debug_file:
-      class: logging.handlers.RotatingFileHandler
-      level: DEBUG
-      formatter: simple
-      filename: logs/saml2_debug.log
-      maxBytes: 104857600 # 100MB
-      backupCount: 20
-      encoding: utf8
-    oidcop_debug_file:
-      class: logging.handlers.RotatingFileHandler
-      level: DEBUG
-      formatter: simple
-      filename: logs/oidcop_debug.log
-      maxBytes: 104857600 # 100MB
-      backupCount: 20
-      encoding: utf8
+    #spid_daily:
+    #  class: logging.handlers.TimedRotatingFileHandler
+    #  level: INFO
+    #  formatter: simple
+    #  filename: logs/spid.log
+    #  when: D
+    #  interval: 1
+    #  backupCount: 860
+    #syslog:
+    #  class: logging.handlers.SysLogHandler
+    #  level: INFO
+    #  formatter: syslog
+    #  saml2_debug_file:
+    #  class: logging.handlers.RotatingFileHandler
+    #  level: DEBUG
+    #  formatter: simple
+    #  filename: logs/saml2_debug.log
+    #  maxBytes: 104857600 # 100MB
+    #  backupCount: 20
+    #  encoding: utf8
+    #oidcop_debug_file:
+    #  class: logging.handlers.RotatingFileHandler
+    #  level: DEBUG
+    #  formatter: simple
+    #  filename: logs/oidcop_debug.log
+    #  maxBytes: 104857600 # 100MB
+    #  backupCount: 20
+    #  encoding: utf8
   loggers:
     satosa:
       level: INFO


### PR DESCRIPTION
Commented unused logs handler, all logs are sended to console (docker default). Any is writed on logs directory and no chmod required on satosa